### PR TITLE
Introduce Action AST 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ build/
 *.c
 *.chi
 a.exe
+.classpath
+.settings/
+bin/
+.project

--- a/src/main/kotlin/gh/marad/chi/actionast/Simplifier.kt
+++ b/src/main/kotlin/gh/marad/chi/actionast/Simplifier.kt
@@ -1,15 +1,23 @@
-package gh.marad.chi.core
+package gh.marad.chi.actionast
 
+import gh.marad.chi.core.Atom
+import gh.marad.chi.core.Block
+import gh.marad.chi.core.Expression
+import gh.marad.chi.core.IfElse
+import gh.marad.chi.core.NameDeclaration
 import gh.marad.chi.core.Type.Companion.i32
+import gh.marad.chi.core.VariableAccess
+import gh.marad.chi.core.analyzer.Scope
 
 /**
  * Simplifies AST so it's easier to evaluate and/or emit C code.
  *
  * Things that it does:
  * - takes inline functions outside, renames them to avoid collisions and updates call sites accordingly
+ * - changes if expressions to functions to make them expressions
  */
-fun simplify(asts: List<Expression>): List<Expression> {
-    return asts
+fun simplify(asts: List<Expression>): List<ActionAst> {
+    return ActionAst.from(Scope() ,asts)
 }
 
 internal fun makeIfAnExpression(tmpVarName: String, ifElse: IfElse): List<Expression> {

--- a/src/main/kotlin/gh/marad/chi/actionast/Simplifier.kt
+++ b/src/main/kotlin/gh/marad/chi/actionast/Simplifier.kt
@@ -1,12 +1,6 @@
 package gh.marad.chi.actionast
 
-import gh.marad.chi.core.Atom
-import gh.marad.chi.core.Block
 import gh.marad.chi.core.Expression
-import gh.marad.chi.core.IfElse
-import gh.marad.chi.core.NameDeclaration
-import gh.marad.chi.core.Type.Companion.i32
-import gh.marad.chi.core.VariableAccess
 import gh.marad.chi.core.analyzer.Scope
 
 /**
@@ -17,22 +11,5 @@ import gh.marad.chi.core.analyzer.Scope
  * - changes if expressions to functions to make them expressions
  */
 fun simplify(asts: List<Expression>): List<ActionAst> {
-    return ActionAst.from(Scope() ,asts)
-}
-
-internal fun makeIfAnExpression(tmpVarName: String, ifElse: IfElse): List<Expression> {
-    fun Block.replaceLastExpressionWithAssignment(name: String): Block {
-        return this
-    }
-
-    return listOf(
-        NameDeclaration(tmpVarName, Atom("0", i32, ifElse.location), false, i32, ifElse.location),
-        IfElse(
-            condition = ifElse.condition,
-            thenBranch = ifElse.thenBranch.replaceLastExpressionWithAssignment(tmpVarName),
-            elseBranch = ifElse.elseBranch?.replaceLastExpressionWithAssignment(tmpVarName),
-            location = ifElse.location
-        ),
-        VariableAccess(tmpVarName, ifElse.location)
-    )
+    return ActionAst.from(asts)
 }

--- a/src/main/kotlin/gh/marad/chi/core/Analyzer.kt
+++ b/src/main/kotlin/gh/marad/chi/core/Analyzer.kt
@@ -49,11 +49,11 @@ data class IfElseBranchesTypeMismatch(val thenBranchType: Type, val elseBranchTy
 // - Weryfikacja istnienia używanych zmiennych
 // - Obecność funkcji `main` bez parametrów (później trzeba będzie ogarnąć listę argumentów)
 
-fun analyze(scope: Scope, exprs: List<Expression>): List<Message> {
+fun analyze(scope: Scope<Expression>, exprs: List<Expression>): List<Message> {
     return exprs.flatMap { analyze(scope, it) }
 }
 
-fun analyze(scope: Scope, expr: Expression): List<Message> {
+fun analyze(scope: Scope<Expression>, expr: Expression): List<Message> {
     // TODO: pozostałe checki
     // Chyba poprawność wywołań i obecność zmiennych w odpowiednich miejscach powinna być przed sprawdzaniem typów.
     // W przeciwnym wypadku wyznaczanie typów wyrażeń może się nie udać

--- a/src/main/kotlin/gh/marad/chi/core/Analyzer.kt
+++ b/src/main/kotlin/gh/marad/chi/core/Analyzer.kt
@@ -49,13 +49,13 @@ data class IfElseBranchesTypeMismatch(val thenBranchType: Type, val elseBranchTy
 // - Weryfikacja istnienia używanych zmiennych
 // - Obecność funkcji `main` bez parametrów (później trzeba będzie ogarnąć listę argumentów)
 
-fun analyze(scope: Scope<Expression>, exprs: List<Expression>): List<Message> {
-    return exprs.flatMap { analyze(scope, it) }
+fun analyze(exprs: List<Expression>): List<Message> {
+    return exprs.flatMap { analyze(it) }
 }
 
-fun analyze(scope: Scope<Expression>, expr: Expression): List<Message> {
+fun analyze(expr: Expression): List<Message> {
     // TODO: pozostałe checki
     // Chyba poprawność wywołań i obecność zmiennych w odpowiednich miejscach powinna być przed sprawdzaniem typów.
     // W przeciwnym wypadku wyznaczanie typów wyrażeń może się nie udać
-    return checkTypes(scope, expr)
+    return checkTypes(expr)
 }

--- a/src/main/kotlin/gh/marad/chi/core/Ast.kt
+++ b/src/main/kotlin/gh/marad/chi/core/Ast.kt
@@ -1,28 +1,76 @@
 package gh.marad.chi.core
 
+import java.util.*
+
 
 sealed interface Expression {
     val location: Location?
 }
+
 data class Atom(val value: String, val type: Type, override val location: Location?): Expression {
     companion object {
         fun unit(location: Location?) = Atom("()", Type.unit, location)
     }
 }
 
-data class VariableAccess(val name: String, override val location: Location?): Expression
+data class VariableAccess(val enclosingScope: NewScope, val name: String, override val location: Location?): Expression
 
-data class Assignment(val name: String, val value: Expression, override val location: Location?) : Expression
+data class Assignment(val enclosingScope: NewScope, val name: String, val value: Expression, override val location: Location?) : Expression
 
 data class NameDeclaration(val name: String, val value: Expression, val immutable: Boolean, val expectedType: Type?, override val location: Location?): Expression
 
 data class FnParam(val name: String, val type: Type, val location: Location?)
-data class Fn(val parameters: List<FnParam>, val returnType: Type, val block: Block, override val location: Location?): Expression {
+data class Fn(val fnScope: NewScope, val parameters: List<FnParam>, val returnType: Type, val block: Block, override val location: Location?): Expression {
     val type = FnType(parameters.map { it.type }, returnType)
 }
 data class Block(val body: List<Expression>, override val location: Location?): Expression
 
-data class FnCall(val name: String, val parameters: List<Expression>, override val location: Location?): Expression
+data class FnCall(val enclosingScope: NewScope, val name: String, val parameters: List<Expression>, override val location: Location?): Expression
 
 data class IfElse(val condition: Expression, val thenBranch: Block, val elseBranch: Block?, override val location: Location?) : Expression
 
+
+data class NewScope(private val definedNames: MutableMap<String, Expression> = mutableMapOf(),
+                    private val parent: NewScope? = null) {
+    private val externalNames: MutableMap<String, Type> = mutableMapOf()
+    private val parameterDefinitions: MutableMap<String, Type> = mutableMapOf()
+
+
+    fun addLocalName(name: String, value: Expression) {
+        definedNames[name] = value
+    }
+
+    fun getLocalName(name: String): Expression? =
+        definedNames[name]
+            ?: parent?.getLocalName(name)
+
+    fun addParameter(name: String, value: Type) {
+        parameterDefinitions[name] = value
+    }
+
+    fun getParameter(name: String): Type? = parameterDefinitions[name]
+
+    fun defineExternalName(name: String, type: Type) {
+        externalNames[name] = type
+    }
+
+    fun getExternalNameType(name: String): Type? = externalNames[name] ?: parent?.getExternalNameType(name)
+
+    override fun toString(): String {
+        return "Scope(definedNames=${definedNames.keys}, parent=$parent, externalNames=$externalNames)"
+    }
+
+    override fun hashCode(): Int {
+        return Objects.hash(definedNames.keys, parent, externalNames)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return if (other is NewScope) {
+            Objects.equals(this.definedNames.keys, other.definedNames.keys)
+                    && Objects.equals(this.parent, other.parent)
+                    && Objects.equals(this.externalNames, other.externalNames)
+        } else {
+            false
+        }
+    }
+}

--- a/src/main/kotlin/gh/marad/chi/core/Ast.kt
+++ b/src/main/kotlin/gh/marad/chi/core/Ast.kt
@@ -13,25 +13,25 @@ data class Atom(val value: String, val type: Type, override val location: Locati
     }
 }
 
-data class VariableAccess(val enclosingScope: NewScope, val name: String, override val location: Location?): Expression
+data class VariableAccess(val enclosingScope: CompilationScope, val name: String, override val location: Location?): Expression
 
-data class Assignment(val enclosingScope: NewScope, val name: String, val value: Expression, override val location: Location?) : Expression
+data class Assignment(val enclosingScope: CompilationScope, val name: String, val value: Expression, override val location: Location?) : Expression
 
 data class NameDeclaration(val name: String, val value: Expression, val immutable: Boolean, val expectedType: Type?, override val location: Location?): Expression
 
 data class FnParam(val name: String, val type: Type, val location: Location?)
-data class Fn(val fnScope: NewScope, val parameters: List<FnParam>, val returnType: Type, val block: Block, override val location: Location?): Expression {
+data class Fn(val fnScope: CompilationScope, val parameters: List<FnParam>, val returnType: Type, val block: Block, override val location: Location?): Expression {
     val type = FnType(parameters.map { it.type }, returnType)
 }
 data class Block(val body: List<Expression>, override val location: Location?): Expression
 
-data class FnCall(val enclosingScope: NewScope, val name: String, val parameters: List<Expression>, override val location: Location?): Expression
+data class FnCall(val enclosingScope: CompilationScope, val name: String, val parameters: List<Expression>, override val location: Location?): Expression
 
 data class IfElse(val condition: Expression, val thenBranch: Block, val elseBranch: Block?, override val location: Location?) : Expression
 
 
-data class NewScope(private val definedNames: MutableMap<String, Expression> = mutableMapOf(),
-                    private val parent: NewScope? = null) {
+data class CompilationScope(private val definedNames: MutableMap<String, Expression> = mutableMapOf(),
+                            private val parent: CompilationScope? = null) {
     private val externalNames: MutableMap<String, Type> = mutableMapOf()
     private val parameterDefinitions: MutableMap<String, Type> = mutableMapOf()
 
@@ -65,7 +65,7 @@ data class NewScope(private val definedNames: MutableMap<String, Expression> = m
     }
 
     override fun equals(other: Any?): Boolean {
-        return if (other is NewScope) {
+        return if (other is CompilationScope) {
             Objects.equals(this.definedNames.keys, other.definedNames.keys)
                     && Objects.equals(this.parent, other.parent)
                     && Objects.equals(this.externalNames, other.externalNames)

--- a/src/main/kotlin/gh/marad/chi/core/Compiler.kt
+++ b/src/main/kotlin/gh/marad/chi/core/Compiler.kt
@@ -5,7 +5,7 @@ import gh.marad.chi.core.analyzer.Scope
 data class CompilationResult(
     val messages: List<Message>,
     val ast: List<Expression>,
-    val scope: Scope,
+    val scope: Scope<Expression>,
 ) {
     fun hasErrors(): Boolean = messages.any { it.level == Level.ERROR }
 }
@@ -17,7 +17,7 @@ data class CompilationResult(
  * @param source Chi source code.
  * @param parentScope Optional scope, so you can add external names.
 */
-fun compile(source: String, parentScope: Scope? = null): CompilationResult {
+fun compile(source: String, parentScope: Scope<Expression>? = null): CompilationResult {
     val ast = parse(tokenize(source))
     val scope = Scope.fromExpressions(ast, parentScope)
     val messages = analyze(scope, ast)

--- a/src/main/kotlin/gh/marad/chi/core/Compiler.kt
+++ b/src/main/kotlin/gh/marad/chi/core/Compiler.kt
@@ -1,11 +1,8 @@
 package gh.marad.chi.core
 
-import gh.marad.chi.core.analyzer.Scope
-
 data class CompilationResult(
     val messages: List<Message>,
     val ast: List<Expression>,
-    val scope: Scope<Expression>,
 ) {
     fun hasErrors(): Boolean = messages.any { it.level == Level.ERROR }
 }
@@ -17,9 +14,8 @@ data class CompilationResult(
  * @param source Chi source code.
  * @param parentScope Optional scope, so you can add external names.
 */
-fun compile(source: String, parentScope: Scope<Expression>? = null): CompilationResult {
-    val ast = parse(tokenize(source))
-    val scope = Scope.fromExpressions(ast, parentScope)
-    val messages = analyze(scope, ast)
-    return CompilationResult(messages, ast, scope)
+fun compile(source: String, parentScope: NewScope? = null): CompilationResult {
+    val ast = parse(tokenize(source), parentScope)
+    val messages = analyze(ast)
+    return CompilationResult(messages, ast)
 }

--- a/src/main/kotlin/gh/marad/chi/core/Compiler.kt
+++ b/src/main/kotlin/gh/marad/chi/core/Compiler.kt
@@ -16,7 +16,7 @@ data class CompilationResult(
  * @param source Chi source code.
  * @param parentScope Optional scope, so you can add external names.
 */
-fun compile(source: String, parentScope: NewScope? = null): CompilationResult {
+fun compile(source: String, parentScope: CompilationScope? = null): CompilationResult {
     val ast = parse(tokenize(source), parentScope)
     val messages = analyze(ast)
     return CompilationResult(messages, ActionAst.from(ast))

--- a/src/main/kotlin/gh/marad/chi/core/Compiler.kt
+++ b/src/main/kotlin/gh/marad/chi/core/Compiler.kt
@@ -1,8 +1,10 @@
 package gh.marad.chi.core
 
+import gh.marad.chi.actionast.ActionAst
+
 data class CompilationResult(
     val messages: List<Message>,
-    val ast: List<Expression>,
+    val ast: List<ActionAst>,
 ) {
     fun hasErrors(): Boolean = messages.any { it.level == Level.ERROR }
 }
@@ -17,5 +19,5 @@ data class CompilationResult(
 fun compile(source: String, parentScope: NewScope? = null): CompilationResult {
     val ast = parse(tokenize(source), parentScope)
     val messages = analyze(ast)
-    return CompilationResult(messages, ast)
+    return CompilationResult(messages, ActionAst.from(ast))
 }

--- a/src/main/kotlin/gh/marad/chi/core/Parser.kt
+++ b/src/main/kotlin/gh/marad/chi/core/Parser.kt
@@ -5,8 +5,8 @@ import gh.marad.chi.core.TokenType.*
 /**
  * Takes list of tokens and produces abstract syntax trees for top-level expressions.
  */
-fun parse(tokens: List<Token>, globalScope: NewScope? = null): List<Expression> {
-    val parser = Parser(globalScope ?: NewScope(), tokens.toTypedArray())
+fun parse(tokens: List<Token>, globalScope: CompilationScope? = null): List<Expression> {
+    val parser = Parser(globalScope ?: CompilationScope(), tokens.toTypedArray())
     val expressions = mutableListOf<Expression>()
 
     while(parser.hasMore()) {
@@ -16,7 +16,7 @@ fun parse(tokens: List<Token>, globalScope: NewScope? = null): List<Expression> 
     return expressions
 }
 
-private class Parser(private var currentScope: NewScope = NewScope(mutableMapOf()),
+private class Parser(private var currentScope: CompilationScope = CompilationScope(mutableMapOf()),
                      private val tokens: Array<Token>) {
     private var currentPosition: Int = 0
 
@@ -209,7 +209,7 @@ private class Parser(private var currentScope: NewScope = NewScope(mutableMapOf(
 
     private fun withNewScope(f: () -> Fn): Fn {
         val parentScope = currentScope
-        currentScope = NewScope(mutableMapOf(), parentScope)
+        currentScope = CompilationScope(mutableMapOf(), parentScope)
         try {
             return f()
         } finally {

--- a/src/main/kotlin/gh/marad/chi/core/Parser.kt
+++ b/src/main/kotlin/gh/marad/chi/core/Parser.kt
@@ -5,8 +5,8 @@ import gh.marad.chi.core.TokenType.*
 /**
  * Takes list of tokens and produces abstract syntax trees for top-level expressions.
  */
-fun parse(tokens: List<Token>): List<Expression> {
-    val parser = Parser(tokens.toTypedArray())
+fun parse(tokens: List<Token>, globalScope: NewScope? = null): List<Expression> {
+    val parser = Parser(globalScope ?: NewScope(), tokens.toTypedArray())
     val expressions = mutableListOf<Expression>()
 
     while(parser.hasMore()) {
@@ -16,7 +16,8 @@ fun parse(tokens: List<Token>): List<Expression> {
     return expressions
 }
 
-private class Parser(private val tokens: Array<Token>) {
+private class Parser(private var currentScope: NewScope = NewScope(mutableMapOf()),
+                     private val tokens: Array<Token>) {
     private var currentPosition: Int = 0
 
     fun hasMore(): Boolean = currentPosition < tokens.size
@@ -56,32 +57,36 @@ private class Parser(private val tokens: Array<Token>) {
         val expectedType = readOptionalTypeDefinition()
         expectOperator("=")
         val valueExpression = readExpression()
+        currentScope.addLocalName(nameSymbol.value, valueExpression)
         return NameDeclaration(nameSymbol.value, valueExpression, immutable, expectedType, variableTypeToken.location)
     }
 
     private fun readAnonymousFunction(): Fn {
-        val fnKeyword = expectKeyword("fn")
-        expectOperator("(")
-        val parameters = mutableListOf<FnParam>()
-        while(peek().value != ")") {
-            parameters.add(readFunctionParameterDefinition())
-            val next = peek()
-            when {
-                next.type == OPERATOR && next.value == "," -> skip()
-                next.type == OPERATOR && next.value == ")" -> break
-                else -> throw OneOfTokensExpected(listOf(",", ")"), next)
+        return withNewScope {
+            val fnKeyword = expectKeyword("fn")
+            expectOperator("(")
+            val parameters = mutableListOf<FnParam>()
+            while(peek().value != ")") {
+                parameters.add(readFunctionParameterDefinition())
+                val next = peek()
+                when {
+                    next.type == OPERATOR && next.value == "," -> skip()
+                    next.type == OPERATOR && next.value == ")" -> break
+                    else -> throw OneOfTokensExpected(listOf(",", ")"), next)
+                }
             }
+            expectOperator(")")
+            val returnType = readOptionalTypeDefinition() ?: Type.unit
+            val body = readBlockExpression()
+            Fn(currentScope, parameters, returnType, body, fnKeyword.location)
         }
-        expectOperator(")")
-        val returnType = readOptionalTypeDefinition() ?: Type.unit
-        val body = readBlockExpression()
-        return Fn(parameters, returnType, body, fnKeyword.location)
     }
 
     private fun readFunctionParameterDefinition(): FnParam {
         val paramName = expectSymbol()
         expectOperator(":")
         val type = readType()
+        currentScope.addParameter(paramName.value, type)
         return FnParam(paramName.value, type, paramName.location)
     }
 
@@ -153,19 +158,19 @@ private class Parser(private val tokens: Array<Token>) {
             }
         }
         expectOperator(")")
-        return FnCall(nameSymbol.value, parametersExpressions, nameSymbol.location)
+        return FnCall(currentScope, nameSymbol.value, parametersExpressions, nameSymbol.location)
     }
 
     private fun readAssignment(): Assignment {
         val nameSymbol = expectSymbol()
         val eqOperator = expectOperator("=")
         val valueExpr = readExpression()
-        return Assignment(nameSymbol.value, valueExpr, eqOperator.location)
+        return Assignment(currentScope, nameSymbol.value, valueExpr, eqOperator.location)
     }
 
     private fun readVariableAccess(): VariableAccess {
         val variableName = expectSymbol()
-        return VariableAccess(variableName.value, variableName.location)
+        return VariableAccess(currentScope, variableName.value, variableName.location)
     }
 
     private fun readAtom(): Atom {
@@ -201,4 +206,14 @@ private class Parser(private val tokens: Array<Token>) {
                     throw UnexpectedToken(it, expectedValue)
                 }
             }
+
+    private fun withNewScope(f: () -> Fn): Fn {
+        val parentScope = currentScope
+        currentScope = NewScope(mutableMapOf(), parentScope)
+        try {
+            return f()
+        } finally {
+            currentScope = parentScope
+        }
+    }
 }

--- a/src/main/kotlin/gh/marad/chi/core/analyzer/Scope.kt
+++ b/src/main/kotlin/gh/marad/chi/core/analyzer/Scope.kt
@@ -1,12 +1,15 @@
 package gh.marad.chi.core.analyzer
 
-import gh.marad.chi.core.*
+import gh.marad.chi.actionast.ActionAst
+import gh.marad.chi.core.Expression
+import gh.marad.chi.core.NameDeclaration
+import gh.marad.chi.core.Type
 
-class Scope(private val parentScope: Scope? = null) {
-    private val variables = mutableMapOf<String, Expression>()
+class Scope<T>(private val parentScope: Scope<T>? = null) {
+    private val variables = mutableMapOf<String, T>()
     private val externalNames = mutableMapOf<String, Type>()
 
-    fun defineVariable(name: String, value: Expression) {
+    fun defineVariable(name: String, value: T) {
         variables[name] = value
     }
 
@@ -18,21 +21,26 @@ class Scope(private val parentScope: Scope? = null) {
         externalNames[externalName]
             ?: parentScope?.getExternalNameType(externalName)
 
-    fun findVariable(name: String): Expression? =
+    fun findVariable(name: String): T? =
         variables[name]
             ?: parentScope?.findVariable(name)
 
     companion object {
-        fun fromExpressions(expression: List<Expression>, parentScope: Scope? = null): Scope {
+        fun fromExpressions(expression: List<Expression>, parentScope: Scope<Expression>? = null): Scope<Expression> {
             val scope = Scope(parentScope)
             expression.forEach { expr ->
-                when(expr) {
-                    is NameDeclaration -> scope.defineVariable(expr.name, expr.value)
-                    is Atom -> {}
-                    is Block -> {}
-                    is Fn -> {}
-                    is FnCall -> {}
-                    is VariableAccess -> {}
+                if (expr is NameDeclaration) {
+                    scope.defineVariable(expr.name, expr.value)
+                }
+            }
+            return scope
+        }
+
+        fun fromActionAst(asts: List<ActionAst>, parentScope: Scope<ActionAst>? = null): Scope<ActionAst> {
+            val scope = Scope(parentScope)
+            asts.forEach { ast ->
+                if (ast is gh.marad.chi.actionast.NameDeclaration) {
+                    scope.defineVariable(ast.name, ast.value)
                 }
             }
             return scope

--- a/src/main/kotlin/gh/marad/chi/core/analyzer/TypeInference.kt
+++ b/src/main/kotlin/gh/marad/chi/core/analyzer/TypeInference.kt
@@ -2,7 +2,7 @@ package gh.marad.chi.core.analyzer
 
 import gh.marad.chi.core.*
 
-fun inferType(scope: Scope, expr: Expression): Type {
+fun inferType(scope: Scope<Expression>, expr: Expression): Type {
     return when(expr) {
         is Assignment -> inferType(scope, expr.value)
         is NameDeclaration -> expr.expectedType ?: inferType(scope, expr.value)
@@ -25,7 +25,7 @@ class MissingVariable(val name: String, val location: Location?) :
 class FunctionExpected(val name: String, val location: Location?) :
         RuntimeException("Variable '$name' is not a function at ${location?.formattedPosition}")
 
-private fun inferFnCallType(scope: Scope, fnCall: FnCall): Type {
+private fun inferFnCallType(scope: Scope<Expression>, fnCall: FnCall): Type {
     val variableType = getVariableType(scope, fnCall.name, fnCall.location)
 
     return if (variableType is FnType) {
@@ -36,7 +36,7 @@ private fun inferFnCallType(scope: Scope, fnCall: FnCall): Type {
 }
 
 
-private fun getVariableType(scope: Scope, name: String, location: Location?): Type {
+private fun getVariableType(scope: Scope<Expression>, name: String, location: Location?): Type {
     return scope.findVariable(name)?.let { inferType(scope, it) }
         ?: scope.getExternalNameType(name)
         ?: throw MissingVariable(name, location)

--- a/src/main/kotlin/gh/marad/chi/core/analyzer/TypeInference.kt
+++ b/src/main/kotlin/gh/marad/chi/core/analyzer/TypeInference.kt
@@ -2,20 +2,25 @@ package gh.marad.chi.core.analyzer
 
 import gh.marad.chi.core.*
 
-fun inferType(scope: Scope<Expression>, expr: Expression): Type {
+fun inferType(expr: Expression): Type {
     return when(expr) {
-        is Assignment -> inferType(scope, expr.value)
-        is NameDeclaration -> expr.expectedType ?: inferType(scope, expr.value)
+        is Assignment -> inferType(expr.value)
+        is NameDeclaration -> expr.expectedType ?: inferType(expr.value)
         is Atom -> expr.type
-        is Block -> expr.body.lastOrNull()?.let { inferType(scope, it) }
+        is Block -> expr.body.lastOrNull()?.let { inferType(it) }
             ?: Type.unit
         is Fn -> FnType(
             paramTypes = expr.parameters.map { it.type },
             returnType = expr.returnType,
         )
-        is FnCall -> inferFnCallType(scope, expr)
-        is VariableAccess -> getVariableType(scope, expr.name, expr.location)
-        is IfElse -> inferType(scope, expr.thenBranch)
+        is FnCall -> inferFnCallType(expr)
+        is VariableAccess ->
+            expr.enclosingScope.getLocalName(expr.name)
+                ?.let(::inferType)
+                ?: expr.enclosingScope.getParameter(expr.name)
+                ?: expr.enclosingScope.getExternalNameType(expr.name)
+                ?: throw MissingVariable(expr.name, expr.location)
+        is IfElse -> inferType(expr.thenBranch)
     }
 }
 
@@ -25,19 +30,16 @@ class MissingVariable(val name: String, val location: Location?) :
 class FunctionExpected(val name: String, val location: Location?) :
         RuntimeException("Variable '$name' is not a function at ${location?.formattedPosition}")
 
-private fun inferFnCallType(scope: Scope<Expression>, fnCall: FnCall): Type {
-    val variableType = getVariableType(scope, fnCall.name, fnCall.location)
+private fun inferFnCallType(fnCall: FnCall): Type {
+    val variableType = fnCall.enclosingScope.getLocalName(fnCall.name)
+        ?.let(::inferType)
+        ?: fnCall.enclosingScope.getParameter(fnCall.name)
+        ?: fnCall.enclosingScope.getExternalNameType(fnCall.name)
+        ?: throw MissingVariable(fnCall.name, fnCall.location)
 
     return if (variableType is FnType) {
         variableType.returnType
     } else {
         throw FunctionExpected(fnCall.name, fnCall.location)
     }
-}
-
-
-private fun getVariableType(scope: Scope<Expression>, name: String, location: Location?): Type {
-    return scope.findVariable(name)?.let { inferType(scope, it) }
-        ?: scope.getExternalNameType(name)
-        ?: throw MissingVariable(name, location)
 }

--- a/src/main/kotlin/gh/marad/chi/interpreter/Interpreter.kt
+++ b/src/main/kotlin/gh/marad/chi/interpreter/Interpreter.kt
@@ -5,7 +5,7 @@ import gh.marad.chi.core.analyzer.Scope
 
 fun repl() {
     val interpreter = Interpreter()
-    val scope = Scope()
+    val scope = Scope<Expression>()
     Prelude.init(scope, interpreter)
     while(true) {
         try {
@@ -40,7 +40,7 @@ private fun show(expr: Expression): String {
 }
 
 object Prelude {
-    fun init(scope: Scope, interpreter: Interpreter) {
+    fun init(scope: Scope<Expression>, interpreter: Interpreter) {
         scope.defineExternalName("println", Type.fn(Type.unit, Type.i32))
         interpreter.registerNativeFunction("println") { _, args ->
             if (args.size != 1) throw RuntimeException("Expected one argument got ${args.size}")
@@ -50,14 +50,23 @@ object Prelude {
     }
 }
 
-class Interpreter {
-    private val nativeFunctions: MutableMap<String, (scope: Scope, args: List<Expression>) -> Expression> = mutableMapOf()
+class ActionInterpreter {
+    private val nativeFunctions: MutableMap<String, (scope: Scope<Expression>, args: List<Expression>) -> Expression> = mutableMapOf()
 
-    fun registerNativeFunction(name: String, function: (scope: Scope, args: List<Expression>) -> Expression) {
+    fun registerNativeFunction(name: String, function: (scope: Scope<Expression>, args: List<Expression>) -> Expression) {
         nativeFunctions[name] = function
     }
 
-    fun eval(scope: Scope, expression: Expression): Expression {
+}
+
+class Interpreter {
+    private val nativeFunctions: MutableMap<String, (scope: Scope<Expression>, args: List<Expression>) -> Expression> = mutableMapOf()
+
+    fun registerNativeFunction(name: String, function: (scope: Scope<Expression>, args: List<Expression>) -> Expression) {
+        nativeFunctions[name] = function
+    }
+
+    fun eval(scope: Scope<Expression>, expression: Expression): Expression {
         return when (expression) {
             is Atom -> expression
             is Assignment -> TODO()
@@ -70,21 +79,21 @@ class Interpreter {
         }
     }
 
-    private fun evalVariableAccess(scope: Scope, expr: VariableAccess): Expression {
+    private fun evalVariableAccess(scope: Scope<Expression>, expr: VariableAccess): Expression {
         return scope.findVariable(expr.name) ?: throw RuntimeException("Name ${expr.name} is not recognized")
     }
 
-    private fun evalNameDeclaration(scope: Scope, expr: NameDeclaration): Expression {
+    private fun evalNameDeclaration(scope: Scope<Expression>, expr: NameDeclaration): Expression {
         val result = eval(scope, expr.value)
         scope.defineVariable(expr.name, result)
         return result
     }
 
-    private fun evalBlockExpression(scope: Scope, expr: Block): Expression {
+    private fun evalBlockExpression(scope: Scope<Expression>, expr: Block): Expression {
         return expr.body.map { eval(scope, it) }.lastOrNull() ?: Atom.unit(expr.location)
     }
 
-    private fun evalFnCall(scope: Scope, expr: FnCall): Expression {
+    private fun evalFnCall(scope: Scope<Expression>, expr: FnCall): Expression {
         val fnExpr = scope.findVariable(expr.name)
         if (fnExpr != null && fnExpr is Fn) {
             val fn = fnExpr

--- a/src/main/kotlin/gh/marad/chi/interpreter/Interpreter.kt
+++ b/src/main/kotlin/gh/marad/chi/interpreter/Interpreter.kt
@@ -86,8 +86,8 @@ class Interpreter {
         return if (compilationResult.hasErrors()) {
             null
         } else {
-            val x = ActionAst.from(compilationResult.ast)
-            x.map(::eval).last()
+            compilationResult.ast
+                .map(::eval).last()
         }
     }
 

--- a/src/main/kotlin/gh/marad/chi/interpreter/Interpreter.kt
+++ b/src/main/kotlin/gh/marad/chi/interpreter/Interpreter.kt
@@ -2,7 +2,7 @@ package gh.marad.chi.interpreter
 
 import gh.marad.chi.actionast.*
 import gh.marad.chi.core.Message
-import gh.marad.chi.core.NewScope
+import gh.marad.chi.core.CompilationScope
 import gh.marad.chi.core.Type
 import gh.marad.chi.core.compile
 
@@ -71,8 +71,8 @@ class Interpreter {
         nativeFunctions[name] = NativeFunction(function, type)
     }
 
-    fun getCompilationScope(): NewScope {
-        val scope = NewScope()
+    fun getCompilationScope(): CompilationScope {
+        val scope = CompilationScope()
         topLevelExecutionScope.getDefinedNamesAndTypes()
             .forEach { scope.defineExternalName(it.key, it.value) }
         nativeFunctions.forEach { scope.defineExternalName(it.key, it.value.type) }

--- a/src/main/kotlin/gh/marad/chi/transpiler/Transpiler.kt
+++ b/src/main/kotlin/gh/marad/chi/transpiler/Transpiler.kt
@@ -39,24 +39,25 @@ private fun String.runCommand(workingDir: File) {
 }
 
 fun transpile(code: String): String {
-    val scope = Scope<Expression>()
-    val result = StringBuilder()
-    result.append("#include <stdio.h>\n")
-    Prelude.init(scope, result)
-
-    val compilationResult = compile(code, scope)
-
-    val emitter = Emitter()
-    compilationResult.messages.forEach { System.err.println(it.message) }
-    if (compilationResult.hasErrors()) {
-        throw RuntimeException("There were compilation errors.")
-    }
-
-    emitter.emit(compilationResult.scope, compilationResult.ast)
-
-    result.append(emitter.getCode())
-    result.append('\n')
-    return result.toString()
+//    val scope = Scope<Expression>()
+//    val result = StringBuilder()
+//    result.append("#include <stdio.h>\n")
+//    Prelude.init(scope, result)
+//
+//    val compilationResult = compile(code, scope)
+//
+//    val emitter = Emitter()
+//    compilationResult.messages.forEach { System.err.println(it.message) }
+//    if (compilationResult.hasErrors()) {
+//        throw RuntimeException("There were compilation errors.")
+//    }
+//
+//    emitter.emit(compilationResult.scope, compilationResult.ast)
+//
+//    result.append(emitter.getCode())
+//    result.append('\n')
+//    return result.toString()
+    return ""
 }
 
 object Prelude {
@@ -159,7 +160,7 @@ class Emitter {
     }
 
     private fun emitVariableDeclaration(scope: Scope<Expression>, expr: NameDeclaration) {
-        val outputType = inferType(scope, expr)
+        val outputType = inferType(expr)
         emitNameAndType(expr.name, outputType)
         sb.append(" = ")
         emit(scope, expr.value)

--- a/src/main/kotlin/gh/marad/chi/transpiler/Transpiler.kt
+++ b/src/main/kotlin/gh/marad/chi/transpiler/Transpiler.kt
@@ -1,8 +1,10 @@
 package gh.marad.chi.transpiler
 
-import gh.marad.chi.core.*
-import gh.marad.chi.core.analyzer.Scope
-import gh.marad.chi.core.analyzer.inferType
+import gh.marad.chi.actionast.*
+import gh.marad.chi.core.CompilationScope
+import gh.marad.chi.core.FnType
+import gh.marad.chi.core.Type
+import gh.marad.chi.core.compile
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -39,29 +41,28 @@ private fun String.runCommand(workingDir: File) {
 }
 
 fun transpile(code: String): String {
-//    val scope = Scope<Expression>()
-//    val result = StringBuilder()
-//    result.append("#include <stdio.h>\n")
-//    Prelude.init(scope, result)
-//
-//    val compilationResult = compile(code, scope)
-//
-//    val emitter = Emitter()
-//    compilationResult.messages.forEach { System.err.println(it.message) }
-//    if (compilationResult.hasErrors()) {
-//        throw RuntimeException("There were compilation errors.")
-//    }
-//
-//    emitter.emit(compilationResult.scope, compilationResult.ast)
-//
-//    result.append(emitter.getCode())
-//    result.append('\n')
-//    return result.toString()
-    return ""
+    val result = StringBuilder()
+    result.append("#include <stdio.h>\n")
+
+    val compilationScope = CompilationScope()
+    Prelude.init(compilationScope, result)
+    val compilationResult = compile(code, compilationScope)
+
+    val emitter = Emitter()
+    compilationResult.messages.forEach { System.err.println(it.message) }
+    if (compilationResult.hasErrors()) {
+        throw RuntimeException("There were compilation errors.")
+    }
+
+    emitter.emit(compilationResult.ast)
+
+    result.append(emitter.getCode())
+    result.append('\n')
+    return result.toString()
 }
 
 object Prelude {
-    fun init(scope: Scope<Expression>, sb: StringBuilder) {
+    fun init(scope: CompilationScope, sb: StringBuilder) {
         scope.defineExternalName("println", Type.fn(Type.unit, Type.i32))
         sb.append("""
             void println(int i) {
@@ -77,47 +78,46 @@ class Emitter {
 
     fun getCode(): String = sb.toString()
 
-    fun emit(scope: Scope<Expression>, exprs: List<Expression>) {
+    fun emit(exprs: List<ActionAst>) {
         exprs.forEach {
-            emit(scope, it)
+            emit(it)
             if (it is NameDeclaration && it.value !is Fn) {
                 sb.append(";\n")
             }
         }
     }
 
-    fun emit(scope: Scope<Expression>, expr: Expression) {
+    fun emit(expr: ActionAst) {
         // this val here is so that `when` give error instead of warn on non-exhaustive match
         val ignored: Any = when(expr) {
             is Atom -> emitAtom(expr)
-            is NameDeclaration -> emitNameDeclaration(scope, expr)
-            is Block -> emitBlock(scope, expr)
+            is NameDeclaration -> emitNameDeclaration(expr)
+            is Block -> emitBlock(expr)
             is Fn -> throw UnsupportedOperationException()
-            is FnCall -> emitFunctionCall(scope, expr)
+            is FnCall -> emitFunctionCall(expr)
             is VariableAccess -> sb.append(expr.name)
-            is Assignment -> emitAssignment(scope, expr)
-            is IfElse -> emitIfElse(scope, expr)
+            is Assignment -> emitAssignment(expr)
+            is IfElse -> emitIfElse(expr)
         }
     }
 
-    private fun emitAssignment(scope: Scope<Expression>, assignment: Assignment) {
+    private fun emitAssignment(assignment: Assignment) {
         sb.append(assignment.name)
         sb.append('=')
-        emit(scope, assignment.value)
+        emit(assignment.value)
     }
 
-    private fun emitNameDeclaration(scope: Scope<Expression>, expr: NameDeclaration) {
+    private fun emitNameDeclaration(expr: NameDeclaration) {
         if (expr.value is Fn) {
-            outputFunctionDeclaration(scope, expr)
+            outputFunctionDeclaration(expr)
         } else {
-            emitVariableDeclaration(scope, expr)
+            emitVariableDeclaration(expr)
         }
     }
 
-    private fun outputFunctionDeclaration(scope: Scope<Expression>, expr: NameDeclaration) {
+    private fun outputFunctionDeclaration(expr: NameDeclaration) {
         // TODO: inlined functions should be declared before (probably with fixed names to avoid collisions)
         val fn = expr.value as Fn
-        val subscope = Scope.fromExpressions(fn.block.body, scope)
 
         emitType(fn.returnType)
         sb.append(' ')
@@ -133,7 +133,7 @@ class Emitter {
         }
         sb.append(')')
         sb.append(" {\n")
-        outputFunctionBody(subscope, fn)
+        outputFunctionBody(fn)
         sb.append("}\n")
     }
 
@@ -159,11 +159,10 @@ class Emitter {
         }
     }
 
-    private fun emitVariableDeclaration(scope: Scope<Expression>, expr: NameDeclaration) {
-        val outputType = inferType(expr)
-        emitNameAndType(expr.name, outputType)
+    private fun emitVariableDeclaration(expr: NameDeclaration) {
+        emitNameAndType(expr.name, expr.type)
         sb.append(" = ")
-        emit(scope, expr.value)
+        emit(expr.value)
     }
 
     private fun emitType(type: Type) {
@@ -176,13 +175,13 @@ class Emitter {
 
     }
 
-    private fun outputFunctionBody(scope: Scope<Expression>, fn: Fn) {
+    private fun outputFunctionBody(fn: Fn) {
         // function declarations should be removed (as they should be handled before)
         // or maybe just make them invalid by language rules?
         // last emit should be prepended by 'return'
         val body = fn.block.body
         body.dropLast(1).forEach {
-            emit(scope, it)
+            emit(it)
             sb.append(";\n")
         }
         if (body.isNotEmpty()) {
@@ -190,20 +189,20 @@ class Emitter {
             if (fn.returnType != Type.unit) {
                 sb.append("return ")
             }
-            emit(scope, it)
+            emit(it)
             sb.append(";\n")
         }
     }
 
-    private fun emitFunctionCall(scope: Scope<Expression>, expr: FnCall) {
+    private fun emitFunctionCall(expr: FnCall) {
         sb.append(expr.name)
         sb.append('(')
         expr.parameters.dropLast(1).forEach {
-            emit(scope, it)
+            emit(it)
             sb.append(", ")
         }
         if (expr.parameters.isNotEmpty()) {
-            emit(scope, expr.parameters.last())
+            emit(expr.parameters.last())
         }
         sb.append(")")
     }
@@ -212,28 +211,28 @@ class Emitter {
         sb.append(expr.value)
     }
 
-    private fun emitBlock(scope: Scope<Expression>, expr: Block) {
+    private fun emitBlock(expr: Block) {
         sb.append("{")
         expr.body.forEach {
-            emit(scope, it)
+            emit(it)
             sb.append(';')
         }
         sb.append("}")
     }
 
-    private fun emitIfElse(scope: Scope<Expression>, expr: IfElse) {
+    private fun emitIfElse(expr: IfElse) {
         // TODO: if-else should be expression (will probably require some tmp variable and
         //  setting it as the last operation of each branch to value of the last expression)
         //  so 'val x = if(true) { 1 } else { 2 }' becomes
         //  int x;
         //  if (...) { x = 1 } else { x = 2 }
         sb.append("if(")
-        emit(scope, expr.condition)
+        emit(expr.condition)
         sb.append(")")
-        emit(scope, expr.thenBranch)
+        emit(expr.thenBranch)
         if (expr.elseBranch != null) {
             sb.append("else")
-            emit(scope, expr.elseBranch)
+            emit(expr.elseBranch)
         }
     }
 }

--- a/src/test/kotlin/gh/marad/chi/Utils.kt
+++ b/src/test/kotlin/gh/marad/chi/Utils.kt
@@ -1,9 +1,10 @@
 package gh.marad.chi
 
 import gh.marad.chi.core.Expression
+import gh.marad.chi.core.NewScope
 import gh.marad.chi.core.parse
 import gh.marad.chi.core.tokenize
 
-fun asts(code: String): List<Expression> = parse(tokenize(code))
-fun ast(code: String): Expression = asts(code).last()
+fun asts(code: String, scope: NewScope = NewScope()): List<Expression> = parse(tokenize(code), scope)
+fun ast(code: String, scope: NewScope = NewScope()): Expression = asts(code, scope).last()
 

--- a/src/test/kotlin/gh/marad/chi/Utils.kt
+++ b/src/test/kotlin/gh/marad/chi/Utils.kt
@@ -1,10 +1,10 @@
 package gh.marad.chi
 
 import gh.marad.chi.core.Expression
-import gh.marad.chi.core.NewScope
+import gh.marad.chi.core.CompilationScope
 import gh.marad.chi.core.parse
 import gh.marad.chi.core.tokenize
 
-fun asts(code: String, scope: NewScope = NewScope()): List<Expression> = parse(tokenize(code), scope)
-fun ast(code: String, scope: NewScope = NewScope()): Expression = asts(code, scope).last()
+fun asts(code: String, scope: CompilationScope = CompilationScope()): List<Expression> = parse(tokenize(code), scope)
+fun ast(code: String, scope: CompilationScope = CompilationScope()): Expression = asts(code, scope).last()
 

--- a/src/test/kotlin/gh/marad/chi/core/ParserSpec.kt
+++ b/src/test/kotlin/gh/marad/chi/core/ParserSpec.kt
@@ -39,7 +39,7 @@ class ParserSpec : FunSpec() {
         }
 
         test("should read function type definition") {
-            val scope = NewScope()
+            val scope = CompilationScope()
             parse(tokenize("val foo: (i32, i32) -> unit = x"), scope)
                 .first()
                 .shouldBe(
@@ -68,7 +68,7 @@ class ParserSpec : FunSpec() {
         }
 
         test("should read basic assignment") {
-            val parentScope = NewScope()
+            val parentScope = CompilationScope()
             parse(tokenize("x = 5"), parentScope)
                 .first()
                 .shouldBe(Assignment(parentScope, "x", Atom("5", i32, Location(0, 4)), Location(0, 2)))
@@ -78,7 +78,7 @@ class ParserSpec : FunSpec() {
                 .shouldBe(Assignment(parentScope,
                     "x",
                     Fn(
-                        fnScope = NewScope(parent = parentScope),
+                        fnScope = CompilationScope(parent = parentScope),
                         parameters = emptyList(),
                         returnType = unit,
                         block = Block(
@@ -92,7 +92,7 @@ class ParserSpec : FunSpec() {
         }
 
         test("should read anonymous function expression") {
-            val scope = NewScope()
+            val scope = CompilationScope()
             parse(tokenize("fn(a: i32, b: i32): i32 {}"), scope)
                 .first()
                 .shouldBe(
@@ -101,20 +101,20 @@ class ParserSpec : FunSpec() {
                         returnType = i32,
                         block = Block(emptyList(), Location(0, 24)),
                         location = Location(0, 0),
-                        fnScope = NewScope(parent=scope)
+                        fnScope = CompilationScope(parent=scope)
                     )
                 )
         }
 
         test("should read variable access through name") {
-            val scope = NewScope()
+            val scope = CompilationScope()
             parse(tokenize("foo"), scope)
                 .first()
                 .shouldBe(VariableAccess(scope, "foo", Location(0, 0)))
         }
 
         test("should read function invocation expression") {
-            val scope = NewScope()
+            val scope = CompilationScope()
             parse(tokenize("add(5, 1)"), scope)
                 .first()
                 .shouldBe(
@@ -150,7 +150,7 @@ class ParserSpec : FunSpec() {
         }
 
         test("should read anonymous function without parameters") {
-            val scope = NewScope()
+            val scope = CompilationScope()
             parse(tokenize("fn(): i32 {}"), scope)
                 .first()
                 .shouldBe(
@@ -159,13 +159,13 @@ class ParserSpec : FunSpec() {
                         returnType = i32,
                         block = Block(emptyList(), Location(0, 10)),
                         location = Location(0, 0),
-                        fnScope = NewScope(parent=scope),
+                        fnScope = CompilationScope(parent=scope),
                     )
                 )
         }
 
         test("should read anonymous function without return type") {
-            val scope = NewScope()
+            val scope = CompilationScope()
             parse(tokenize("fn() {}"), scope)
                 .first()
                 .shouldBe(
@@ -174,7 +174,7 @@ class ParserSpec : FunSpec() {
                         returnType = unit,
                         block = Block(emptyList(), Location(0, 5)),
                         location = Location(0, 0),
-                        fnScope = NewScope(parent=scope),
+                        fnScope = CompilationScope(parent=scope),
                     )
                 )
         }

--- a/src/test/kotlin/gh/marad/chi/core/SimplifierSpec.kt
+++ b/src/test/kotlin/gh/marad/chi/core/SimplifierSpec.kt
@@ -1,10 +1,10 @@
 package gh.marad.chi.core
 
+import gh.marad.chi.actionast.makeIfAnExpression
 import gh.marad.chi.ast
 import gh.marad.chi.asts
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainInOrder
-import io.kotest.matchers.shouldBe
 
 class SimplifierSpec : FunSpec() {
     init {

--- a/src/test/kotlin/gh/marad/chi/core/SimplifierSpec.kt
+++ b/src/test/kotlin/gh/marad/chi/core/SimplifierSpec.kt
@@ -1,26 +1,25 @@
 package gh.marad.chi.core
 
-import gh.marad.chi.actionast.makeIfAnExpression
 import gh.marad.chi.ast
 import gh.marad.chi.asts
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainInOrder
 
-class SimplifierSpec : FunSpec() {
-    init {
-        test("should make `if` an expression-like") {
-            val input = ast("""
-                if (1) { 2 } else { 3 }
-            """.trimIndent())
-
-            val expectedOutput = asts("""
-                var tmp = 0
-                if (1) { tmp = 2 } else { tmp = 3 }
-                tmp
-            """.trimIndent())
-
-
-            makeIfAnExpression("tmp", input as IfElse).shouldContainInOrder(expectedOutput)
-        }
-    }
-}
+//class SimplifierSpec : FunSpec() {
+//    init {
+//        test("should make `if` an expression-like") {
+//            val input = ast("""
+//                if (1) { 2 } else { 3 }
+//            """.trimIndent())
+//
+//            val expectedOutput = asts("""
+//                var tmp = 0
+//                if (1) { tmp = 2 } else { tmp = 3 }
+//                tmp
+//            """.trimIndent())
+//
+//
+//            makeIfAnExpression("tmp", input as IfElse).shouldContainInOrder(expectedOutput)
+//        }
+//    }
+//}

--- a/src/test/kotlin/gh/marad/chi/core/analyzer/ScopeSpec.kt
+++ b/src/test/kotlin/gh/marad/chi/core/analyzer/ScopeSpec.kt
@@ -1,5 +1,6 @@
 package gh.marad.chi.core.analyzer
 
+import gh.marad.chi.core.Expression
 import gh.marad.chi.core.Type
 import gh.marad.chi.core.parse
 import gh.marad.chi.core.tokenize
@@ -29,7 +30,7 @@ class ScopeSpec : FunSpec() {
 
         test("scope should find external name types in parent scope") {
             // given
-            val parentScope = Scope()
+            val parentScope = Scope<Expression>()
             val childScope = Scope(parentScope)
             parentScope.defineExternalName("foo", Type.i32)
 
@@ -39,7 +40,7 @@ class ScopeSpec : FunSpec() {
 
         test("function scope should also have parameter types") {
             // given
-            val scope = Scope()
+            val scope = Scope<Expression>()
 
             // when
             scope.defineExternalName("x", Type.i32)
@@ -68,7 +69,7 @@ class ScopeSpec : FunSpec() {
         }
 
         test("should return null when function or variable is not found") {
-            val emptyScope = Scope()
+            val emptyScope = Scope<Expression>()
             emptyScope.findVariable("nonExisting").shouldBeNull()
         }
     }

--- a/src/test/kotlin/gh/marad/chi/core/analyzer/TypeCheckingSpec.kt
+++ b/src/test/kotlin/gh/marad/chi/core/analyzer/TypeCheckingSpec.kt
@@ -14,18 +14,19 @@ import io.kotest.matchers.collections.shouldHaveSize
 class AssignmentTypeCheckingSpec : FunSpec() {
     init {
         test("should check that type of the variable matches type of the expression") {
-            val scope = Scope.fromExpressions(asts("var x = 5"))
-            checkTypes(scope, ast("x = 10")).shouldBeEmpty()
-            checkTypes(scope, ast("x = fn() {}")).shouldHaveSingleElement(
+            val scope = NewScope()
+            scope.addLocalName("x", ast("5"))
+            checkTypes(ast("x = 10", scope)).shouldBeEmpty()
+            checkTypes(ast("x = fn() {}", scope)).shouldHaveSingleElement(
                 TypeMismatch(i32, Type.fn(unit), Location(0, 2))
             )
         }
 
         test("should check that type of external variable matches type of the expresion") {
-            val scope = Scope<Expression>()
+            val scope = NewScope()
             scope.defineExternalName("x", i32)
-            checkTypes(scope, ast("x = 10")).shouldBeEmpty()
-            checkTypes(scope, ast("x = fn() {}")).shouldHaveSingleElement(
+            checkTypes(ast("x = 10", scope)).shouldBeEmpty()
+            checkTypes(ast("x = fn() {}", scope)).shouldHaveSingleElement(
                 TypeMismatch(i32, Type.fn(unit), Location(0, 2))
             )
         }
@@ -36,21 +37,22 @@ class NameDeclarationTypeCheckingSpec : FunSpec() {
     init {
 
         test("should return nothing for simple atom and variable read") {
-            val scope = Scope.fromExpressions(asts("val x = fn() {}"))
-            checkTypes(scope, ast("5")).shouldBeEmpty()
-            checkTypes(scope, ast("x")).shouldBeEmpty()
+            val scope = NewScope()
+            scope.addLocalName("x", ast("val x = fn() {}"))
+            checkTypes(ast("5", scope)).shouldBeEmpty()
+            checkTypes(ast("x", scope)).shouldBeEmpty()
         }
 
         test("should check if types match in name declaration with type definition") {
-            checkTypes(Scope(), ast("val x: () -> i32 = 5"))
+            checkTypes(ast("val x: () -> i32 = 5"))
                 .shouldHaveSingleElement(
                     TypeMismatch(Type.fn(i32), i32, Location(0, 19))
                 )
         }
 
         test("should pass valid name declarations") {
-            checkTypes(Scope(), ast("val x: i32 = 5")).shouldBeEmpty()
-            checkTypes(Scope(), ast("val x = 5")).shouldBeEmpty()
+            checkTypes(ast("val x: i32 = 5")).shouldBeEmpty()
+            checkTypes(ast("val x = 5")).shouldBeEmpty()
         }
     }
 }
@@ -63,7 +65,7 @@ class BlockExpressionTypeCheckingSpec : FunSpec() {
                 fn(): i32 {}
             """.trimIndent()), null)
 
-            val errors = checkTypes(Scope(), block)
+            val errors = checkTypes(block)
             errors.shouldHaveSize(2)
             errors.shouldContain(TypeMismatch(Type.fn(i32), i32, Location(0, 19)))
             errors.shouldContain(MissingReturnValue(i32, Location(1, 10)))
@@ -74,27 +76,27 @@ class BlockExpressionTypeCheckingSpec : FunSpec() {
 class FnTypeCheckingSpec : FunSpec() {
     init {
         test("should not return errors on valid function definition") {
-            checkTypes(Scope(), ast("fn(x: i32): i32 { x }")).shouldBeEmpty()
+            checkTypes(ast("fn(x: i32): i32 { x }")).shouldBeEmpty()
         }
 
         test("should check for missing return value only if function expects the return type") {
-            checkTypes(Scope(), ast("fn() {}"))
+            checkTypes(ast("fn() {}"))
                 .shouldBeEmpty()
-            checkTypes(Scope(), ast("fn(): i32 {}"))
+            checkTypes(ast("fn(): i32 {}"))
                 .shouldHaveSingleElement(MissingReturnValue(i32, Location(0, 10)))
         }
 
         test("should check that block return type matches what function expects") {
-            checkTypes(Scope(), ast("fn(): i32 { fn() {} }"))
+            checkTypes(ast("fn(): i32 { fn() {} }"))
                 .shouldHaveSingleElement(TypeMismatch(i32, Type.fn(unit), Location(0, 12)))
 
             // should point to '{' of the block when it's empty instead of last expression
-            checkTypes(Scope(), ast("fn(): i32 {}"))
+            checkTypes(ast("fn(): i32 {}"))
                 .shouldHaveSingleElement(MissingReturnValue(i32, Location(0, 10)))
         }
 
         test("should also check types for expressions in function body") {
-            checkTypes(Scope(), ast("""
+            checkTypes(ast("""
                 fn(x: i32): i32 {
                     val i: i32 = fn() {}
                     x
@@ -107,17 +109,17 @@ class FnTypeCheckingSpec : FunSpec() {
 
 class FnCallTypeCheckingSpec : FunSpec() {
     init {
-
-        val scope = Scope.fromExpressions(asts("val test = fn(a: i32, b: () -> unit): i32 { a }"))
+        val scope = NewScope()
+        scope.addLocalName("test", ast("fn(a: i32, b: () -> unit): i32 { a }"))
 
         test("should check that parameter argument types match") {
-            checkTypes(scope, ast("test(10, fn(){})")).shouldBeEmpty()
-            checkTypes(scope, ast("test(10, 20)"))
+            checkTypes(ast("test(10, fn(){})", scope)).shouldBeEmpty()
+            checkTypes(ast("test(10, 20)", scope))
                 .shouldHaveSingleElement(TypeMismatch(Type.fn(unit), i32, Location(0, 9)))
         }
 
         test("should check function arity") {
-            checkTypes(scope, ast("test(1)"))
+            checkTypes(ast("test(1)", scope))
                 .shouldHaveSingleElement(FunctionArityError("test", 2, 1, Location(0, 0)))
         }
     }
@@ -126,9 +128,9 @@ class FnCallTypeCheckingSpec : FunSpec() {
 class IfElseTypeCheckingSpec : FunSpec() {
     init {
         test("should check that if and else branches have the same type") {
-            checkTypes(Scope(), ast("if(1) { 2 }")).shouldBeEmpty()
-            checkTypes(Scope(), ast("if(1) { 2 } else { 3 }")).shouldBeEmpty()
-            checkTypes(Scope(), ast("if(1) { 2 } else { fn() {} }"))
+            checkTypes(ast("if(1) { 2 }")).shouldBeEmpty()
+            checkTypes(ast("if(1) { 2 } else { 3 }")).shouldBeEmpty()
+            checkTypes(ast("if(1) { 2 } else { fn() {} }"))
                 .shouldHaveSingleElement(
                     IfElseBranchesTypeMismatch(i32, Type.fn(unit))
                 )

--- a/src/test/kotlin/gh/marad/chi/core/analyzer/TypeCheckingSpec.kt
+++ b/src/test/kotlin/gh/marad/chi/core/analyzer/TypeCheckingSpec.kt
@@ -22,7 +22,7 @@ class AssignmentTypeCheckingSpec : FunSpec() {
         }
 
         test("should check that type of external variable matches type of the expresion") {
-            val scope = Scope()
+            val scope = Scope<Expression>()
             scope.defineExternalName("x", i32)
             checkTypes(scope, ast("x = 10")).shouldBeEmpty()
             checkTypes(scope, ast("x = fn() {}")).shouldHaveSingleElement(

--- a/src/test/kotlin/gh/marad/chi/core/analyzer/TypeCheckingSpec.kt
+++ b/src/test/kotlin/gh/marad/chi/core/analyzer/TypeCheckingSpec.kt
@@ -14,7 +14,7 @@ import io.kotest.matchers.collections.shouldHaveSize
 class AssignmentTypeCheckingSpec : FunSpec() {
     init {
         test("should check that type of the variable matches type of the expression") {
-            val scope = NewScope()
+            val scope = CompilationScope()
             scope.addLocalName("x", ast("5"))
             checkTypes(ast("x = 10", scope)).shouldBeEmpty()
             checkTypes(ast("x = fn() {}", scope)).shouldHaveSingleElement(
@@ -23,7 +23,7 @@ class AssignmentTypeCheckingSpec : FunSpec() {
         }
 
         test("should check that type of external variable matches type of the expresion") {
-            val scope = NewScope()
+            val scope = CompilationScope()
             scope.defineExternalName("x", i32)
             checkTypes(ast("x = 10", scope)).shouldBeEmpty()
             checkTypes(ast("x = fn() {}", scope)).shouldHaveSingleElement(
@@ -37,7 +37,7 @@ class NameDeclarationTypeCheckingSpec : FunSpec() {
     init {
 
         test("should return nothing for simple atom and variable read") {
-            val scope = NewScope()
+            val scope = CompilationScope()
             scope.addLocalName("x", ast("val x = fn() {}"))
             checkTypes(ast("5", scope)).shouldBeEmpty()
             checkTypes(ast("x", scope)).shouldBeEmpty()
@@ -109,7 +109,7 @@ class FnTypeCheckingSpec : FunSpec() {
 
 class FnCallTypeCheckingSpec : FunSpec() {
     init {
-        val scope = NewScope()
+        val scope = CompilationScope()
         scope.addLocalName("test", ast("fn(a: i32, b: () -> unit): i32 { a }"))
 
         test("should check that parameter argument types match") {

--- a/src/test/kotlin/gh/marad/chi/core/analyzer/TypeInferenceSpec.kt
+++ b/src/test/kotlin/gh/marad/chi/core/analyzer/TypeInferenceSpec.kt
@@ -1,5 +1,7 @@
 package gh.marad.chi.core.analyzer
 
+import gh.marad.chi.ast
+import gh.marad.chi.asts
 import gh.marad.chi.core.*
 import gh.marad.chi.core.Type.Companion.i32
 import gh.marad.chi.core.Type.Companion.unit
@@ -9,27 +11,26 @@ import io.kotest.matchers.shouldBe
 
 class TypeInferenceSpec : FunSpec() {
     init {
-        fun asts(code: String): List<Expression> = parse(tokenize(code))
-        fun ast(code: String): Expression = asts(code).last()
         test("should read type from assignment's value") {
-            inferType(Scope(), ast("x = 5")).shouldBe(i32)
+            inferType(ast("x = 5")).shouldBe(i32)
         }
 
         test("should read type for simple atom") {
-            inferType(Scope(), ast("5")).shouldBe(i32)
+            inferType(ast("5")).shouldBe(i32)
         }
 
         test("should read type from definition") {
-            inferType(Scope(), ast("val x: i32 = 0")).shouldBe(i32)
+            inferType(ast("val x: i32 = 0")).shouldBe(i32)
         }
 
         test("should infer type from declaration expression") {
-            inferType(Scope(), ast("val x = 0")).shouldBe(i32)
+            inferType(ast("val x = 0")).shouldBe(i32)
         }
 
         test("should infer type form accessing variable in scope")  {
-            val scope = Scope.fromExpressions(asts("val x = 10"))
-            inferType(scope, ast("x")).shouldBe(i32)
+            val scope = NewScope()
+            scope.addLocalName("x", ast("10"))
+            inferType(ast("x", scope)).shouldBe(i32)
         }
 
         test("block type is depends on it's last expression") {
@@ -37,77 +38,78 @@ class TypeInferenceSpec : FunSpec() {
                 fn() {}
                 14
             """.trimIndent()), null)
-            inferType(Scope(), block).shouldBe(i32)
+            inferType(block).shouldBe(i32)
         }
 
         test("empty block is of type 'unit'") {
-            inferType(Scope(), Block(emptyList(), null)).shouldBe(unit)
+            inferType(Block(emptyList(), null)).shouldBe(unit)
         }
 
         test("functions should have '() -> unit' type") {
-            inferType(Scope(), ast("fn() {}")).shouldBe(Type.fn(unit))
+            inferType(ast("fn() {}")).shouldBe(Type.fn(unit))
+        }
+
+        test("should take parameters into account") {
+            val fn = ast("fn(x: i32): i32 { x }") as Fn
+            inferType(fn.block.body.first())
+                .shouldBe(i32)
         }
 
         test("function calls should have it's returned value type") {
-            val scope = Scope.fromExpressions(asts("""
-                    val main = fn() {}
-                    val foo = fn(): i32 { 5 }
-                """.trimIndent()))
-            inferType(scope, ast("main()")).shouldBe(unit)
-            inferType(scope, ast("foo()")).shouldBe(i32)
+            val scope = NewScope()
+            scope.addLocalName("main", ast("fn() {}"))
+            scope.addLocalName("foo", ast("fn(): i32 { 5 }"))
+
+            inferType(ast("main()", scope)).shouldBe(unit)
+            inferType(ast("foo()", scope)).shouldBe(i32)
         }
 
         test("function calls should use external names") {
-            val scope = Scope<Expression>()
+            val scope = NewScope()
             scope.defineExternalName("ext", i32)
             scope.defineExternalName("extFn", Type.fn(unit, i32))
 
-            inferType(scope, ast("ext")).shouldBe(i32)
-            inferType(scope, ast("extFn")).shouldBe(Type.fn(unit, i32))
-            inferType(scope, ast("extFn()")).shouldBe(unit)
+            inferType(ast("ext", scope)).shouldBe(i32)
+            inferType(ast("extFn", scope)).shouldBe(Type.fn(unit, i32))
+            inferType(ast("extFn()", scope)).shouldBe(unit)
         }
 
         test("locally defined names should shadow external ones") {
-            val scope = Scope<Expression>()
+            val scope = NewScope()
             scope.defineExternalName("foo", Type.fn(i32))
-            inferType(scope, ast("foo()")).shouldBe(i32)
-            inferType(scope, ast("foo")).shouldBe(Type.fn(i32))
+            inferType(ast("foo()", scope)).shouldBe(i32)
+            inferType(ast("foo", scope)).shouldBe(Type.fn(i32))
 
-            scope.defineVariable("foo", ast("fn(x: i32) {}"))
+            scope.addLocalName("foo", ast("fn(x: i32) {}"))
 
-            inferType(scope, ast("foo()")).shouldBe(unit)
-            inferType(scope, ast("foo")).shouldBe(Type.fn(returnType = unit, i32))
+            inferType(ast("foo()", scope)).shouldBe(unit)
+            inferType(ast("foo", scope)).shouldBe(Type.fn(returnType = unit, i32))
         }
 
         test("should throw exception when scope does not contain required variable") {
-            val emptyScope = Scope<Expression>()
-
-            shouldThrow<MissingVariable> { inferType(emptyScope, ast("notExisting")) }
-            shouldThrow<MissingVariable> { inferType(emptyScope, ast("notExisting()"))}
+            shouldThrow<MissingVariable> { inferType(ast("notExisting")) }
+            shouldThrow<MissingVariable> { inferType(ast("notExisting()"))}
         }
 
         test("should infer type for function call when expression evaluates to function") {
-            val scope = Scope.fromExpressions(asts("""
-                val test = fn(x: i32, y: i32): i32 { y }
-                val foo = test
-            """.trimIndent()))
+            val scope = NewScope()
+            scope.addLocalName("test", ast("fn(x: i32, y: i32): i32 { y }", scope))
+            scope.addLocalName("foo", ast("test", scope))
 
-            inferType(scope, ast("foo()"))
+            inferType(ast("foo()", scope))
         }
 
         test("should throw exception when trying to invoke function") {
             // TODO - with type hierarchy if-else expression should have the "broader" type
-            val scope = Scope.fromExpressions(asts("""
-                val x = 5
-            """.trimIndent()))
+            val scope = NewScope()
+            scope.addLocalName("x", ast("5"))
 
-            shouldThrow<FunctionExpected> { inferType(scope, ast("x()")) }
+            shouldThrow<FunctionExpected> { inferType(ast("x()", scope)) }
         }
 
         test("should infer type for if-else expression") {
-            inferType(Scope(), ast("if(1) { 2 }")).shouldBe(i32)
-            inferType(Scope(), ast("if(1) { 2 } else { 3 }")).shouldBe(i32)
+            inferType(ast("if(1) { 2 }")).shouldBe(i32)
+            inferType(ast("if(1) { 2 } else { 3 }")).shouldBe(i32)
         }
-
     }
 }

--- a/src/test/kotlin/gh/marad/chi/core/analyzer/TypeInferenceSpec.kt
+++ b/src/test/kotlin/gh/marad/chi/core/analyzer/TypeInferenceSpec.kt
@@ -58,7 +58,7 @@ class TypeInferenceSpec : FunSpec() {
         }
 
         test("function calls should use external names") {
-            val scope = Scope()
+            val scope = Scope<Expression>()
             scope.defineExternalName("ext", i32)
             scope.defineExternalName("extFn", Type.fn(unit, i32))
 
@@ -68,7 +68,7 @@ class TypeInferenceSpec : FunSpec() {
         }
 
         test("locally defined names should shadow external ones") {
-            val scope = Scope()
+            val scope = Scope<Expression>()
             scope.defineExternalName("foo", Type.fn(i32))
             inferType(scope, ast("foo()")).shouldBe(i32)
             inferType(scope, ast("foo")).shouldBe(Type.fn(i32))
@@ -80,7 +80,7 @@ class TypeInferenceSpec : FunSpec() {
         }
 
         test("should throw exception when scope does not contain required variable") {
-            val emptyScope = Scope()
+            val emptyScope = Scope<Expression>()
 
             shouldThrow<MissingVariable> { inferType(emptyScope, ast("notExisting")) }
             shouldThrow<MissingVariable> { inferType(emptyScope, ast("notExisting()"))}

--- a/src/test/kotlin/gh/marad/chi/core/analyzer/TypeInferenceSpec.kt
+++ b/src/test/kotlin/gh/marad/chi/core/analyzer/TypeInferenceSpec.kt
@@ -28,7 +28,7 @@ class TypeInferenceSpec : FunSpec() {
         }
 
         test("should infer type form accessing variable in scope")  {
-            val scope = NewScope()
+            val scope = CompilationScope()
             scope.addLocalName("x", ast("10"))
             inferType(ast("x", scope)).shouldBe(i32)
         }
@@ -56,7 +56,7 @@ class TypeInferenceSpec : FunSpec() {
         }
 
         test("function calls should have it's returned value type") {
-            val scope = NewScope()
+            val scope = CompilationScope()
             scope.addLocalName("main", ast("fn() {}"))
             scope.addLocalName("foo", ast("fn(): i32 { 5 }"))
 
@@ -65,7 +65,7 @@ class TypeInferenceSpec : FunSpec() {
         }
 
         test("function calls should use external names") {
-            val scope = NewScope()
+            val scope = CompilationScope()
             scope.defineExternalName("ext", i32)
             scope.defineExternalName("extFn", Type.fn(unit, i32))
 
@@ -75,7 +75,7 @@ class TypeInferenceSpec : FunSpec() {
         }
 
         test("locally defined names should shadow external ones") {
-            val scope = NewScope()
+            val scope = CompilationScope()
             scope.defineExternalName("foo", Type.fn(i32))
             inferType(ast("foo()", scope)).shouldBe(i32)
             inferType(ast("foo", scope)).shouldBe(Type.fn(i32))
@@ -92,7 +92,7 @@ class TypeInferenceSpec : FunSpec() {
         }
 
         test("should infer type for function call when expression evaluates to function") {
-            val scope = NewScope()
+            val scope = CompilationScope()
             scope.addLocalName("test", ast("fn(x: i32, y: i32): i32 { y }", scope))
             scope.addLocalName("foo", ast("test", scope))
 
@@ -101,7 +101,7 @@ class TypeInferenceSpec : FunSpec() {
 
         test("should throw exception when trying to invoke function") {
             // TODO - with type hierarchy if-else expression should have the "broader" type
-            val scope = NewScope()
+            val scope = CompilationScope()
             scope.addLocalName("x", ast("5"))
 
             shouldThrow<FunctionExpected> { inferType(ast("x()", scope)) }

--- a/src/test/kotlin/gh/marad/chi/interpreter/EvalSpec.kt
+++ b/src/test/kotlin/gh/marad/chi/interpreter/EvalSpec.kt
@@ -20,7 +20,7 @@ class EvalSpec : FunSpec() {
 
         test("evaling variable read should return value from scope") {
             // given
-            val scope = Scope()
+            val scope = Scope<Expression>()
             scope.defineVariable("foo", intAtom)
             val interpreter = Interpreter()
 
@@ -32,7 +32,7 @@ class EvalSpec : FunSpec() {
         test("evaluating name declaration should update scope") {
             // given
             val interpreter = Interpreter()
-            val scope = Scope()
+            val scope = Scope<Expression>()
 
             // when
             val result = interpreter.eval(scope, NameDeclaration("x", intAtom, immutable = true, expectedType = Type.i32, null))
@@ -72,7 +72,7 @@ class EvalSpec : FunSpec() {
             // given
             val interpreter = Interpreter()
             val lastAtom = Atom("10", Type.i32, null)
-            val scope = Scope()
+            val scope = Scope<Expression>()
 
             // when
             interpreter.eval(scope, Block(listOf(
@@ -110,7 +110,7 @@ class EvalSpec : FunSpec() {
                 returnType = Type.i32,
                 block = body
             , null)
-            val scope = Scope()
+            val scope = Scope<Expression>()
             scope.defineVariable("foo", fn)
             val interpreter = Interpreter()
 

--- a/src/test/kotlin/gh/marad/chi/interpreter/FnCallSpec.kt
+++ b/src/test/kotlin/gh/marad/chi/interpreter/FnCallSpec.kt
@@ -7,14 +7,14 @@ import io.kotest.matchers.shouldBe
 
 class FnCallSpec : FunSpec() {
 
-    private fun Interpreter.eval(scope: Scope, code: String) =
+    private fun Interpreter.eval(scope: Scope<Expression>, code: String) =
         parse(tokenize(code)).map { eval(scope, it) }.last()
 
     init {
         test("body should have access to outer scope") {
             // given
             val interpreter = Interpreter()
-            val scope = Scope()
+            val scope = Scope<Expression>()
             interpreter.eval(scope, "val x = 5")
             interpreter.eval(scope, "val foo = fn() { x }")
 
@@ -28,7 +28,7 @@ class FnCallSpec : FunSpec() {
         test("function should be able to use arguments") {
             // given
             val interpreter = Interpreter()
-            val scope = Scope()
+            val scope = Scope<Expression>()
             interpreter.eval(scope, "val x = 5")
             interpreter.eval(scope, "val foo = fn(bar: i32) { bar }")
 
@@ -42,7 +42,7 @@ class FnCallSpec : FunSpec() {
         test("arguments should hide parent scope variables with the same name") {
             // given
             val interpreter = Interpreter()
-            val scope = Scope()
+            val scope = Scope<Expression>()
             interpreter.eval(scope, "val x = 5")
             interpreter.eval(scope, "val foo = fn(x: i32) { x }")
 

--- a/src/test/kotlin/gh/marad/chi/interpreter/FnCallSpec.kt
+++ b/src/test/kotlin/gh/marad/chi/interpreter/FnCallSpec.kt
@@ -1,71 +1,71 @@
 package gh.marad.chi.interpreter
 
 import gh.marad.chi.core.*
-import gh.marad.chi.core.analyzer.Scope
+import gh.marad.chi.core.Type.Companion.i32
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
 class FnCallSpec : FunSpec() {
 
-    private fun Interpreter.eval(scope: Scope<Expression>, code: String) =
-        parse(tokenize(code)).map { eval(scope, it) }.last()
-
     init {
+        test("unit function should not return value of the last expression") {
+            val interpreter = Interpreter()
+            interpreter.eval("val main = fn(x: i32) { x }")
+            interpreter.eval("main(10)").shouldBe(Atom.unit(null))
+        }
+
         test("body should have access to outer scope") {
             // given
             val interpreter = Interpreter()
-            val scope = Scope<Expression>()
-            interpreter.eval(scope, "val x = 5")
-            interpreter.eval(scope, "val foo = fn() { x }")
+            interpreter.eval("val x = 5")
+            interpreter.eval("val foo = fn(): i32 { x }")
 
             // when
-            val result = interpreter.eval(scope, "foo()")
+            val result = interpreter.eval("foo()")
 
             // then
-            result.shouldBe(Atom("5", Type.i32, Location(0, 8)))
+            result.shouldBe(Atom("5", i32, Location(0, 8)))
         }
 
         test("function should be able to use arguments") {
             // given
             val interpreter = Interpreter()
-            val scope = Scope<Expression>()
-            interpreter.eval(scope, "val x = 5")
-            interpreter.eval(scope, "val foo = fn(bar: i32) { bar }")
+            interpreter.eval("val x = 5")
+            interpreter.eval("val foo = fn(bar: i32): i32 { bar }")
 
             // when
-            val result = interpreter.eval(scope, "foo(10)")
+            val result = interpreter.eval("foo(10)")
 
             // then
-            result.shouldBe(Atom("10", Type.i32, Location(0, 4)))
+            result.shouldBe(Atom("10", i32, Location(0, 4)))
         }
 
         test("arguments should hide parent scope variables with the same name") {
             // given
             val interpreter = Interpreter()
-            val scope = Scope<Expression>()
-            interpreter.eval(scope, "val x = 5")
-            interpreter.eval(scope, "val foo = fn(x: i32) { x }")
+            interpreter.eval("val x = 5")
+            interpreter.eval("val foo = fn(x: i32): i32 { x }")
 
             // when
-            val result = interpreter.eval(scope, "foo(10)")
+            val result = interpreter.eval("foo(10)")
 
             // then
-            result.shouldBe(Atom("10", Type.i32, Location(0, 4)))
+            result.shouldBe(Atom("10", i32, Location(0, 4)))
         }
 
         test("using native functions") {
             // given
             val interpreter = Interpreter()
-            interpreter.registerNativeFunction("add") { _, args ->
+            interpreter.registerNativeFunction("add", Type.fn(i32, i32, i32)) { _, args ->
                 val a = (args[0] as Atom).value.toInt()
                 val b = (args[1] as Atom).value.toInt()
-                Atom((a+b).toString(), Type.i32, null)
+                Atom((a+b).toString(), i32, null)
             }
 
             // expect
-            interpreter.eval(Scope(), "add(5, 3)")
+            interpreter.eval("add(5, 3)")
                 .shouldBe(
-                    Atom("8", Type.i32, null)
+                    Atom("8", i32, null)
                 )
 
         }

--- a/src/test/kotlin/gh/marad/chi/interpreter/FnCallSpec.kt
+++ b/src/test/kotlin/gh/marad/chi/interpreter/FnCallSpec.kt
@@ -1,6 +1,7 @@
 package gh.marad.chi.interpreter
 
-import gh.marad.chi.core.*
+import gh.marad.chi.actionast.Atom
+import gh.marad.chi.core.Type
 import gh.marad.chi.core.Type.Companion.i32
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -11,7 +12,7 @@ class FnCallSpec : FunSpec() {
         test("unit function should not return value of the last expression") {
             val interpreter = Interpreter()
             interpreter.eval("val main = fn(x: i32) { x }")
-            interpreter.eval("main(10)").shouldBe(Atom.unit(null))
+            interpreter.eval("main(10)").shouldBe(Atom.unit)
         }
 
         test("body should have access to outer scope") {
@@ -24,7 +25,7 @@ class FnCallSpec : FunSpec() {
             val result = interpreter.eval("foo()")
 
             // then
-            result.shouldBe(Atom("5", i32, Location(0, 8)))
+            result.shouldBe(Atom("5", i32))
         }
 
         test("function should be able to use arguments") {
@@ -37,7 +38,7 @@ class FnCallSpec : FunSpec() {
             val result = interpreter.eval("foo(10)")
 
             // then
-            result.shouldBe(Atom("10", i32, Location(0, 4)))
+            result.shouldBe(Atom("10", i32))
         }
 
         test("arguments should hide parent scope variables with the same name") {
@@ -50,7 +51,7 @@ class FnCallSpec : FunSpec() {
             val result = interpreter.eval("foo(10)")
 
             // then
-            result.shouldBe(Atom("10", i32, Location(0, 4)))
+            result.shouldBe(Atom("10", i32))
         }
 
         test("using native functions") {
@@ -59,13 +60,13 @@ class FnCallSpec : FunSpec() {
             interpreter.registerNativeFunction("add", Type.fn(i32, i32, i32)) { _, args ->
                 val a = (args[0] as Atom).value.toInt()
                 val b = (args[1] as Atom).value.toInt()
-                Atom((a+b).toString(), i32, null)
+                Atom.i32(a+b)
             }
 
             // expect
             interpreter.eval("add(5, 3)")
                 .shouldBe(
-                    Atom("8", i32, null)
+                    Atom("8", i32)
                 )
 
         }


### PR DESCRIPTION
Add ActiionAST to separate compilation scopes and checks from execution/transpilation.

Thanks to this Interpreter and Transpiler no longer depend on CompilationScopes 